### PR TITLE
feat(API-800): Create database index on transaction tables

### DIFF
--- a/gdc_ng_models/models/submission.py
+++ b/gdc_ng_models/models/submission.py
@@ -179,6 +179,13 @@ class TransactionSnapshot(Base):
 
     __tablename__ = 'transaction_snapshots'
 
+    @declared_attr
+    def __table_args__(cls):
+        return (
+            Index('idx_transaction_snapshots_transactions_id', 'transaction_id'),
+        )
+
+
     def __repr__(self):
         return "<TransactionSnapshot({}, {})>".format(
             self.id, self.transaction_id)
@@ -230,6 +237,12 @@ class TransactionSnapshot(Base):
 class TransactionDocument(Base):
 
     __tablename__ = 'transaction_documents'
+
+    @declared_attr
+    def __table_args__(cls):
+        return (
+            Index('idx_transaction_document_transactions_id', 'transaction_id'),
+        )
 
     def to_json(self, fields=None):
         # Source fields


### PR DESCRIPTION
The index creation was already done on the prod database so this won't
really affect us. This change will only affect new database created from
these models.