### PR TITLE
Feat/dev 118 add id to released data

### DIFF
--- a/gdc_ng_models/models/released_data.py
+++ b/gdc_ng_models/models/released_data.py
@@ -1,4 +1,5 @@
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import validates
 from sqlalchemy.sql import schema, sqltypes
 
@@ -54,6 +55,10 @@ class ReleasedData(Base, audit.AuditColumnsMixin, ReleasedDataMixin):
             "is_controlled": self.is_controlled,
             "is_open": self.is_open,
         }
+
+    @hybrid_property
+    def id(self):
+        return "{}_{}_{}".format(self.program_name, self.project_code, self.data_type)
 
 
 class ReleasedDataLog(Base, audit.AuditColumnsMixin, ReleasedDataMixin):

--- a/tests/test_released_data.py
+++ b/tests/test_released_data.py
@@ -74,7 +74,7 @@ def test_released_data__project_id(fake_released_data, db_session):
 def test_released_data__id(fake_released_data, db_session):
     fake_released_data()
     node = db_session.query(released_data.ReleasedData).first()
-    assert node.id == "{}_{}_{}".format(node.program_name, node.project_code, node.data_type)
+    assert node.id == "name_code_cnv", "id for ReleasedData is not correct."
 
 
 def test_release_data_log__sqlalchemy_model_registered():

--- a/tests/test_released_data.py
+++ b/tests/test_released_data.py
@@ -71,6 +71,12 @@ def test_released_data__project_id(fake_released_data, db_session):
     assert node.project_id == "{}-{}".format(node.program_name, node.project_code)
 
 
+def test_released_data__id(fake_released_data, db_session):
+    fake_released_data()
+    node = db_session.query(released_data.ReleasedData).first()
+    assert node.id == "{}_{}_{}".format(node.program_name, node.project_code, node.data_type)
+
+
 def test_release_data_log__sqlalchemy_model_registered():
     assert released_data.ReleasedDataLog
 


### PR DESCRIPTION
Add `id` as a `hybrid_property` in `ReleasedData` class. This `id` will be used as `snapshot_id` in the transactions related to the RD objects.