### PR TITLE
DEV-551 pin setuptools-scm range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='gdc_ng_models',
-    setup_requires=["setuptools_scm"],
+    name="gdc_ng_models",
+    setup_requires=["setuptools_scm<6"],
     use_scm_version={"local_scheme": "dirty-tag", "fallback_version": "local"},
-    description='Non-graph GDC models',
-    license='Apache',
+    description="Non-graph GDC models",
+    license="Apache",
     packages=find_packages(),
     scripts=[
-        'bin/ng-models',
+        "bin/ng-models",
     ],
 )


### PR DESCRIPTION
setuptools-scm 6.0.0 and 6.0.1 broke py27 build

versions 6.0.0 and 6.0.1 came out March 17th and subsequently broke the py27 build. Pinning to versions before 6.0.0.

https://pypi.org/project/setuptools-scm/#history
https://github.com/pypa/setuptools_scm/blob/main/CHANGELOG.rst
