### PR TITLE
chore: move alembic to extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=find_packages(),
     package_data={"gdc_ng_models": ["alembic/*"]},
     include_package_data=True,
-    install_requires=["alembic~=1.4"],
+    extras_require={"alembic": ["alembic~=1.4"]},
     scripts=[
         "bin/ng-models",
     ],


### PR DESCRIPTION
This makes consumers of gdc-ng-models default to opt-out of installing alembic, since most consumers do not need it.