### PR TITLE
DEV-1673: Add accessed datetime column to cohort table

### DIFF
--- a/gdc_ng_models/models/accessed.py
+++ b/gdc_ng_models/models/accessed.py
@@ -1,0 +1,23 @@
+"""Mixin for adding an accessed timestamp column to track the last time a record was accessed."""
+import datetime
+
+from sqlalchemy import schema, sql
+from sqlalchemy.sql import sqltypes
+
+
+class AccessedColumnMixin:
+    """A mixin to add accessed timestamp column to a data model.
+
+    Attributes:
+        accessed_datetime: Metadata describing when a row was last accessed.
+    """
+
+    def __init__(self):
+        pass
+
+    accessed_datetime = schema.Column(
+        sqltypes.DateTime(timezone=True),
+        nullable=False,
+        server_default=sql.text("now()"),
+        onupdate=datetime.datetime.utcnow,
+    )

--- a/gdc_ng_models/models/cohort.py
+++ b/gdc_ng_models/models/cohort.py
@@ -13,7 +13,7 @@ import uuid
 import sqlalchemy
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext import declarative
-from gdc_ng_models.models import audit
+from gdc_ng_models.models import accessed, audit
 
 Base = declarative.declarative_base()
 
@@ -73,7 +73,7 @@ class AnonymousContext(Base, audit.AuditColumnsMixin):
         }
 
 
-class Cohort(Base, audit.AuditColumnsMixin):
+class Cohort(Base, audit.AuditColumnsMixin, accessed.AccessedColumnMixin):
     """A base definition for a cohort entity.
 
     Attributes:
@@ -81,7 +81,8 @@ class Cohort(Base, audit.AuditColumnsMixin):
         context_id: The ID of the associated context.
         name: A user defined name for the cohort.
         created_datetime: The date and time when the record is created.
-        updated_datetime: The date and time when the record is updated.
+        updated_datetime: The date and time when the record is last updated.
+        accessed_datetime: The date and time when the record is last accessed.
     """
 
     __tablename__ = "cohort"
@@ -121,7 +122,8 @@ class Cohort(Base, audit.AuditColumnsMixin):
             "name='{name}', "
             "context_id={context_id}, "
             "created_datetime={created_datetime}, "
-            "updated_datetime={updated_datetime})>".format(
+            "updated_datetime={updated_datetime}), "
+            "accessed_datetime={accessed_datetime})>".format(
                 id=self.id,
                 name=self.name,
                 context_id=self.context_id,
@@ -130,6 +132,9 @@ class Cohort(Base, audit.AuditColumnsMixin):
                 else None,
                 updated_datetime=self.updated_datetime.isoformat()
                 if self.updated_datetime
+                else None,
+                accessed_datetime=self.accessed_datetime.isoformat()
+                if self.accessed_datetime
                 else None,
             )
         )
@@ -144,6 +149,9 @@ class Cohort(Base, audit.AuditColumnsMixin):
             else None,
             "updated_datetime": self.updated_datetime.isoformat()
             if self.updated_datetime
+            else None,
+            "accessed_datetime": self.accessed_datetime.isoformat()
+            if self.accessed_datetime
             else None,
         }
 

--- a/tests/integration/models/test_cohort.py
+++ b/tests/integration/models/test_cohort.py
@@ -320,6 +320,7 @@ def test_cohort__to_json(create_cohort_db, db_session, fixture_context):
                 "context_id": str(test_cohort.context_id),
                 "created_datetime": test_cohort.created_datetime.isoformat(),
                 "updated_datetime": test_cohort.updated_datetime.isoformat(),
+                "accessed_datetime": test_cohort.accessed_datetime.isoformat(),
             }
         )
     )


### PR DESCRIPTION
In preparation for data retention and purge strategies, an accessed timestamp column is being added to the cohort table. It will be automatically updated whenever the record is updated. Planned changes to cohortapi and gdcapi will be necessary to track read operations.