### PR TITLE
DEV-2301 externalize enums so that they can be accessed by other modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,11 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.11.5
+    hooks:
+      - id: isort
+        args: [--profile, black]
   - repo: git@github.com:Yelp/detect-secrets
     rev: v1.4.0
     hooks:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -135,7 +135,7 @@
         "filename": "gdc_ng_models/alembic/versions/12dbbcac7a1d_change_columns_to_biginteger.py",
         "hashed_secret": "e9a4b5d5cbc26e98f00981d15146f2a23871666b",
         "is_verified": false,
-        "line_number": 14,
+        "line_number": 13,
         "is_secret": false
       }
     ],
@@ -145,10 +145,10 @@
         "filename": "gdc_ng_models/alembic/versions/e9d53a640d5d_add_start_end_datetimes_notifications.py",
         "hashed_secret": "e9a4b5d5cbc26e98f00981d15146f2a23871666b",
         "is_verified": false,
-        "line_number": 13,
+        "line_number": 12,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2023-12-01T15:26:37Z"
+  "generated_at": "2023-12-01T15:34:13Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -21,14 +21,11 @@
       "name": "CloudantDetector"
     },
     {
-      "name": "DiscordBotTokenDetector"
-    },
-    {
       "name": "GitHubTokenDetector"
     },
     {
       "name": "HexHighEntropyString",
-      "limit": 3
+      "limit": 3.0
     },
     {
       "name": "IbmCloudIamDetector"
@@ -109,12 +106,6 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
-    },
-    {
-      "path": "detect_secrets.filters.regex.should_exclude_file",
-      "pattern": [
-        "^.secrets.baseline$"
-      ]
     }
   ],
   "results": {
@@ -159,5 +150,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-25T14:30:18Z"
+  "generated_at": "2023-12-01T15:26:37Z"
 }

--- a/gdc_ng_models/alembic/env.py
+++ b/gdc_ng_models/alembic/env.py
@@ -1,8 +1,7 @@
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy import engine_from_config
-from sqlalchemy import pool
+from sqlalchemy import engine_from_config, pool
 
 import gdc_ng_models.models.batch as batch_models
 import gdc_ng_models.models.download_reports as download_reports_models
@@ -14,7 +13,6 @@ import gdc_ng_models.models.released_data as released_data_models
 import gdc_ng_models.models.reports as reports_models
 import gdc_ng_models.models.studyrule as studyrule_models
 import gdc_ng_models.models.submission as submission_models
-
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/gdc_ng_models/alembic/versions/12dbbcac7a1d_change_columns_to_biginteger.py
+++ b/gdc_ng_models/alembic/versions/12dbbcac7a1d_change_columns_to_biginteger.py
@@ -5,9 +5,8 @@ Revises: e9d53a640d5d
 Create Date: 2021-03-30 13:16:01.055456
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "12dbbcac7a1d"

--- a/gdc_ng_models/alembic/versions/e9d53a640d5d_add_start_end_datetimes_notifications.py
+++ b/gdc_ng_models/alembic/versions/e9d53a640d5d_add_start_end_datetimes_notifications.py
@@ -5,9 +5,8 @@ Revises:
 Create Date: 2020-12-11 16:06:21.960486
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "e9d53a640d5d"

--- a/gdc_ng_models/models/audit.py
+++ b/gdc_ng_models/models/audit.py
@@ -1,7 +1,7 @@
 """Common audit metadata for our data models."""
 import datetime
 
-from sqlalchemy import schema, sql, func
+from sqlalchemy import func, schema, sql
 from sqlalchemy.sql import sqltypes
 
 

--- a/gdc_ng_models/models/cohort.py
+++ b/gdc_ng_models/models/cohort.py
@@ -10,9 +10,11 @@ cohort data model includes the following entities:
 """
 
 import uuid
+
 import sqlalchemy
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext import declarative
+
 from gdc_ng_models.models import accessed, audit
 
 Base = declarative.declarative_base()

--- a/gdc_ng_models/models/download_reports.py
+++ b/gdc_ng_models/models/download_reports.py
@@ -1,8 +1,8 @@
 import json
-import sqlalchemy as db
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.dialects.postgresql import JSONB
 
+import sqlalchemy as db
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()
 

--- a/gdc_ng_models/models/entity_set.py
+++ b/gdc_ng_models/models/entity_set.py
@@ -86,15 +86,15 @@ class EntitySet(Base, audit.AuditColumnsMixin, accessed.AccessedColumnMixin):
         return (
             "<EntitySet("
             "id={id}, "
-            "type={type.name}, "
-            "entity_type={entity_type.name}, "
+            "type={type}, "
+            "entity_type={entity_type}, "
             "entity_ids={entity_ids}, "
             "created_datetime={created_datetime}, "
             "updated_datetime={updated_datetime}), "
             "accessed_datetime={accessed_datetime})>".format(
                 id=self.id,
-                type=self.type,
-                entity_type=self.entity_type,
+                type=self.type.name,
+                entity_type=self.entity_type.name,
                 entity_ids=self.entity_ids,
                 created_datetime=self.created_datetime.isoformat()
                 if self.created_datetime
@@ -111,8 +111,8 @@ class EntitySet(Base, audit.AuditColumnsMixin, accessed.AccessedColumnMixin):
     def to_json(self):
         return {
             "id": str(self.id),
-            "type": str(self.type.name),
-            "entity_type": str(self.entity_type.name),
+            "type": self.type.name,
+            "entity_type": self.entity_type.name,
             "entity_ids": [str(entity_id) for entity_id in self.entity_ids],
             "created_datetime": self.created_datetime.isoformat()
             if self.created_datetime

--- a/gdc_ng_models/models/entity_set.py
+++ b/gdc_ng_models/models/entity_set.py
@@ -19,11 +19,13 @@ Sets can be discussed in this context
   by the cohort service in the backend system.
 """
 
+import enum
+
 import sqlalchemy
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext import declarative
+
 from gdc_ng_models.models import accessed, audit
-import enum
 
 
 @enum.unique

--- a/gdc_ng_models/models/misc.py
+++ b/gdc_ng_models/models/misc.py
@@ -1,7 +1,6 @@
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import BigInteger, Column, DateTime, Index, String, Text, Sequence
+from sqlalchemy import BigInteger, Column, DateTime, Index, Sequence, String, Text
 from sqlalchemy.dialects.postgresql import JSONB
-
+from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()
 

--- a/gdc_ng_models/models/notifications.py
+++ b/gdc_ng_models/models/notifications.py
@@ -2,17 +2,16 @@ import json
 
 from sqlalchemy import (
     BigInteger,
+    Boolean,
     Column,
+    DateTime,
+    Sequence,
     String,
     Text,
-    DateTime,
     text,
-    Boolean,
-    Sequence,
 )
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.dialects.postgresql import ARRAY
-
+from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()
 

--- a/gdc_ng_models/models/qcreport.py
+++ b/gdc_ng_models/models/qcreport.py
@@ -5,15 +5,14 @@ from sqlalchemy import (
     DateTime,
     Enum,
     ForeignKey,
+    Sequence,
     String,
     Text,
     text,
-    Sequence,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, validates
-from sqlalchemy.dialects.postgresql import JSONB
-
 
 Base = declarative_base()
 SEVERITY = Enum("CRITICAL", "WARNING", "PASSED", name="error_severity")

--- a/gdc_ng_models/models/redaction.py
+++ b/gdc_ng_models/models/redaction.py
@@ -1,20 +1,20 @@
 from datetime import datetime
+
 from sqlalchemy import (
-    Boolean,
     BigInteger,
+    Boolean,
     Column,
     DateTime,
     Enum,
     ForeignKey,
+    Sequence,
     String,
     Text,
     text,
-    Sequence,
 )
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
-
 
 Base = declarative_base()
 

--- a/gdc_ng_models/models/reports.py
+++ b/gdc_ng_models/models/reports.py
@@ -1,8 +1,7 @@
-from sqlalchemy import BigInteger, Column, Text, DateTime, text, Index, func, Sequence
+from sqlalchemy import BigInteger, Column, DateTime, Index, Sequence, Text, func, text
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.dialects.postgresql import JSONB
-
 
 Base = declarative_base()
 

--- a/gdc_ng_models/models/submission.py
+++ b/gdc_ng_models/models/submission.py
@@ -5,26 +5,28 @@ gdcdatamodel.models.submission
 Models for submission TransactionLogs
 """
 
-from distutils.version import StrictVersion
 from datetime import datetime
-from json import loads, dumps
+from distutils.version import StrictVersion
+from json import dumps, loads
+
 import pytz
 import sqlalchemy as db
-from sqlalchemy import func, Sequence
-from sqlalchemy.ext.declarative import declarative_base, declared_attr
-from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import relationship, deferred
 from sqlalchemy import (
     BigInteger,
     Boolean,
     Column,
     DateTime,
     ForeignKey,
-    Integer,
     Index,
+    Integer,
+    Sequence,
     Text,
+    func,
     text,
 )
+from sqlalchemy.ext.declarative import declarative_base, declared_attr
+from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.orm import deferred, relationship
 
 if StrictVersion(db.__version__) >= StrictVersion("1.3.4"):
     from sqlalchemy.dialects.postgresql.json import JSONB

--- a/gdc_ng_models/snacks/database.py
+++ b/gdc_ng_models/snacks/database.py
@@ -5,7 +5,6 @@ from sqlalchemy import create_engine
 
 from gdc_ng_models.utils.decorators import try_or_log_error
 
-
 logger = getLogger(__name__)
 
 PERMISSIONS = dict(READ="SELECT", WRITE="SELECT, INSERT, UPDATE, DELETE")

--- a/tests/integration/models/test_cohort.py
+++ b/tests/integration/models/test_cohort.py
@@ -1,9 +1,11 @@
 import enum
 import json
 import uuid
+
 import pytest
-from gdc_ng_models.models import cohort
 from sqlalchemy import exc
+
+from gdc_ng_models.models import cohort
 
 
 class CohortType(enum.Enum):

--- a/tests/integration/models/test_download_reports_models.py
+++ b/tests/integration/models/test_download_reports_models.py
@@ -1,10 +1,8 @@
 from datetime import date
 
 from cdisutils.dictionary import sort_dict
-from gdc_ng_models.models.download_reports import (
-    DataDownloadReport,
-    DataUsageReport,
-)
+
+from gdc_ng_models.models.download_reports import DataDownloadReport, DataUsageReport
 
 
 def test_create_usage_reports(create_reports_db, db_session):

--- a/tests/integration/models/test_entity_set.py
+++ b/tests/integration/models/test_entity_set.py
@@ -6,23 +6,9 @@ Validations that need to be enforced programmatically as they
   * EntitySet.entity_ids values cannot exceed 36 characters
   * EntitySet.entity_ids should be a unique 'set' not an array of values
 """
-import enum
 import json
 import pytest
 from gdc_ng_models.models import entity_set
-
-
-class SetType(enum.Enum):
-    ephemeral = 1
-    frozen = 2
-    mutable = 2
-
-
-class EntityType(enum.Enum):
-    case = 1
-    file = 2
-    gene = 3
-    ssm = 4
 
 
 STRING_36_CHAR = "00000000-0000-0000-0000-000000000000"
@@ -35,8 +21,8 @@ def create_nominal_entity_set() -> entity_set.EntitySet:
     """Helper to build a complete entity set to use for testing"""
     return entity_set.EntitySet(
         id=STRING_128_CHAR,
-        type=SetType.frozen.name,
-        entity_type=EntityType.case.name,
+        type=entity_set.SetType.frozen,
+        entity_type=entity_set.EntityType.case,
         entity_ids=[STRING_36_CHAR],
     )
 
@@ -48,8 +34,8 @@ def test_entity_set_create(create_entity_set_db, db_session):
     db_session.commit()
 
     assert objectUnderTest.id == STRING_128_CHAR
-    assert objectUnderTest.type == SetType.frozen.name
-    assert objectUnderTest.entity_type == EntityType.case.name
+    assert objectUnderTest.type == entity_set.SetType.frozen
+    assert objectUnderTest.entity_type == entity_set.EntityType.case
     assert objectUnderTest.entity_ids == [STRING_36_CHAR]
     assert objectUnderTest.accessed_datetime
     assert objectUnderTest.created_datetime
@@ -122,8 +108,8 @@ def test_entity_set_to_json(create_entity_set_db, db_session):
         json.dumps(
             {
                 "id": STRING_128_CHAR,
-                "type": SetType.frozen.name,
-                "entity_type": EntityType.case.name,
+                "type": entity_set.SetType.frozen.name,
+                "entity_type": entity_set.EntityType.case.name,
                 "entity_ids": [STRING_36_CHAR],
                 "created_datetime": objectUnderTest.created_datetime.isoformat(),
                 "updated_datetime": objectUnderTest.updated_datetime.isoformat(),

--- a/tests/integration/models/test_entity_set.py
+++ b/tests/integration/models/test_entity_set.py
@@ -7,9 +7,10 @@ Validations that need to be enforced programmatically as they
   * EntitySet.entity_ids should be a unique 'set' not an array of values
 """
 import json
-import pytest
-from gdc_ng_models.models import entity_set
 
+import pytest
+
+from gdc_ng_models.models import entity_set
 
 STRING_36_CHAR = "00000000-0000-0000-0000-000000000000"
 STRING_37_CHAR = "00000000-0000-0000-0000-0000000000001"

--- a/tests/integration/models/test_qc_models.py
+++ b/tests/integration/models/test_qc_models.py
@@ -1,5 +1,6 @@
-import pytest
 import uuid
+
+import pytest
 
 from gdc_ng_models.models import qcreport
 

--- a/tests/integration/models/test_redaction_entities.py
+++ b/tests/integration/models/test_redaction_entities.py
@@ -1,11 +1,9 @@
-import pytest
 import random
 import uuid
 
-from gdc_ng_models.models.redaction import (
-    RedactionEntry,
-    RedactionLog,
-)
+import pytest
+
+from gdc_ng_models.models.redaction import RedactionEntry, RedactionLog
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
A bit of a false start. Externalized the enums so they can be used outside the module by clients.