### PR TITLE
DEV-2665: Add downloaded_size_gb and user_interest_files_count to each DataDownloadReport JSONB column.

### DIFF
--- a/src/gdc_ng_models/models/download_reports.py
+++ b/src/gdc_ng_models/models/download_reports.py
@@ -83,9 +83,17 @@ class DataUsageReport(Base):
         )
 
 
+SIZE_FIELD = "downloaded_size_gb"
+COUNT_FIELD = "user_interest_files_count"
+
+
 class DataDownloadReport(Base):
 
     __tablename__ = "data_download_report"
+
+    @staticmethod
+    def _create_default():
+        return {SIZE_FIELD: 0, COUNT_FIELD: 0}
 
     report_period = db.Column(db.Date, primary_key=True, nullable=False)
 
@@ -104,7 +112,7 @@ class DataDownloadReport(Base):
         db.DateTime(timezone=True), nullable=False, server_default=db.text("now()")
     )
 
-    def add_access_type(self, access_type, size):
+    def add_size_access_type(self, access_type, size):
         """
         Args:
             access_type (str): open/closed
@@ -112,9 +120,11 @@ class DataDownloadReport(Base):
         """
         if not self.access_type_report:
             self.access_type_report = {}
-        self.access_type_report[access_type] = size
+        if access_type not in self.access_type_report:
+            self.access_type_report[access_type] = DataDownloadReport._create_default()
+        self.access_type_report[access_type][SIZE_FIELD] = size
 
-    def add_experimental_strategy(self, strategy, size):
+    def add_size_experimental_strategy(self, strategy, size):
         """
         Args:
             strategy (str): strategy name
@@ -122,9 +132,13 @@ class DataDownloadReport(Base):
         """
         if not self.experimental_strategy_report:
             self.experimental_strategy_report = {}
-        self.experimental_strategy_report[strategy] = size
+        if strategy not in self.experimental_strategy_report:
+            self.experimental_strategy_report[strategy] = (
+                DataDownloadReport._create_default()
+            )
+        self.experimental_strategy_report[strategy][SIZE_FIELD] = size
 
-    def add_project_id(self, project, size):
+    def add_size_project_id(self, project, size):
         """
         Args:
             project id (str): project's name
@@ -132,9 +146,11 @@ class DataDownloadReport(Base):
         """
         if not self.project_id_report:
             self.project_id_report = {}
-        self.project_id_report[project] = size
+        if project not in self.project_id_report:
+            self.project_id_report[project] = DataDownloadReport._create_default()
+        self.project_id_report[project][SIZE_FIELD] = size
 
-    def add_access_location(self, location, size):
+    def add_size_access_location(self, location, size):
         """
         Args:
             location (str): location name (country code)
@@ -142,7 +158,59 @@ class DataDownloadReport(Base):
         """
         if not self.access_location_report:
             self.access_location_report = {}
-        self.access_location_report[location] = size
+        if location not in self.access_location_report:
+            self.access_location_report[location] = DataDownloadReport._create_default()
+        self.access_location_report[location][SIZE_FIELD] = size
+
+    def add_count_access_type(self, access_type, count):
+        """
+        Args:
+            access_type (str): open/closed
+            count (double): count
+        """
+        if not self.access_type_report:
+            self.access_type_report = {}
+        if access_type not in self.access_type_report:
+            self.access_type_report[access_type] = DataDownloadReport._create_default()
+        self.access_type_report[access_type][COUNT_FIELD] = count
+
+    def add_count_experimental_strategy(self, strategy, count):
+        """
+        Args:
+            strategy (str): strategy name
+            count (double): count
+        """
+        if not self.experimental_strategy_report:
+            self.experimental_strategy_report = {}
+        if strategy not in self.experimental_strategy_report:
+            self.experimental_strategy_report[strategy] = (
+                DataDownloadReport._create_default()
+            )
+        self.experimental_strategy_report[strategy][COUNT_FIELD] = count
+
+    def add_count_project_id(self, project, count):
+        """
+        Args:
+            project id (str): project's name
+            count (double): count
+        """
+        if not self.project_id_report:
+            self.project_id_report = {}
+        if project not in self.project_id_report:
+            self.project_id_report[project] = DataDownloadReport._create_default()
+        self.project_id_report[project][COUNT_FIELD] = count
+
+    def add_count_access_location(self, location, count):
+        """
+        Args:
+            location (str): location name (country code)
+            count (double): count
+        """
+        if not self.access_location_report:
+            self.access_location_report = {}
+        if location not in self.access_location_report:
+            self.access_location_report[location] = DataDownloadReport._create_default()
+        self.access_location_report[location][COUNT_FIELD] = count
 
     def to_json(self):
         """Returns a JSON safe representation of :class:`DataDownloadReport`"""

--- a/tests/integration/models/test_download_reports_models.py
+++ b/tests/integration/models/test_download_reports_models.py
@@ -1,6 +1,7 @@
 import json
 from datetime import date
 
+import pytest
 from cdisutils.dictionary import sort_dict
 
 from gdc_ng_models.models.download_reports import DataDownloadReport, DataUsageReport
@@ -121,4 +122,35 @@ def test_download_report_to_json_contains_size_and_count():
             "last_updated": "None"
         }
         """
+    )
+
+
+_SIZE_COUNT_PROP_MAP = {
+    "size": "downloaded_size_gb",
+    "count": "user_interest_files_count",
+}
+
+
+@pytest.mark.parametrize("size_or_count", (("size", "count")))
+@pytest.mark.parametrize(
+    "field_name",
+    ("access_type", "project_id", "access_location", "experimental_strategy"),
+)
+def test_download_report_to_json_contains_field_with_value(field_name, size_or_count):
+    report = DataDownloadReport()
+    adder_method = getattr(report, f"add_{size_or_count}_{field_name}")
+
+    adder_method(field_name, 123)
+    report.to_json() == json.loads(
+        """
+        {
+            "%(field_name)s_report": {
+                "%(size_or_count_prop)s": 123
+            }
+        }
+        """
+        % {
+            "field_name": field_name,
+            "size_or_count_prop": _SIZE_COUNT_PROP_MAP[size_or_count],
+        }
     )

--- a/tests/integration/models/test_download_reports_models.py
+++ b/tests/integration/models/test_download_reports_models.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date
 
 from cdisutils.dictionary import sort_dict
@@ -72,3 +73,52 @@ def test_create_download_report(create_reports_db, db_session):
     assert rp.project_id_report == report.project_id_report
     assert rp.date_created == report.date_created
     assert rp.last_updated == report.last_updated
+
+
+def test_download_report_to_json_contains_size_and_count():
+
+    report = DataDownloadReport()
+
+    report.add_size_access_type("open", 100.0)
+    report.add_size_experimental_strategy("WXS", 101.0)
+    report.add_size_project_id("TCGA-YYY", 330)
+    report.add_count_access_type("closed", 3)
+    report.add_count_access_location("San Francisco, CA, USA", 303)
+
+    assert report.to_json() == json.loads(
+        """
+        {
+            "access_type_report": {
+                "open": {
+                    "downloaded_size_gb": 100.0,
+                    "user_interest_files_count": 0
+                },
+                "closed": {
+                    "downloaded_size_gb": 0,
+                    "user_interest_files_count": 3
+                }
+            },
+            "experimental_strategy_report": {
+                "WXS": {
+                    "downloaded_size_gb": 101.0,
+                    "user_interest_files_count": 0
+                }
+            },
+            "project_id_report": {
+                "TCGA-YYY": {
+                    "downloaded_size_gb": 330.0,
+                    "user_interest_files_count": 0
+                }
+            },
+            "access_location_report": {
+                "San Francisco, CA, USA": {
+                    "downloaded_size_gb": 0,
+                    "user_interest_files_count": 303
+                }
+            },
+            "report_period": "None",
+            "date_created": "None",
+            "last_updated": "None"
+        }
+        """
+    )

--- a/tests/integration/models/test_download_reports_models.py
+++ b/tests/integration/models/test_download_reports_models.py
@@ -38,11 +38,16 @@ def test_create_download_report(create_reports_db, db_session):
 
     report = DataDownloadReport()
 
-    report.add_access_type("open", 100.0)
-    report.add_access_type("closed", 33.0)
-    report.add_experimental_strategy("WXS", 100.0)
-    report.add_access_location("San Francisco, CA, USA", 300)
-    report.add_project_id("TCGA-YYY", 330)
+    report.add_size_access_type("open", 100.0)
+    report.add_size_access_type("closed", 33.0)
+    report.add_size_experimental_strategy("WXS", 100.0)
+    report.add_size_access_location("San Francisco, CA, USA", 300)
+    report.add_size_project_id("TCGA-YYY", 330)
+    report.add_count_access_type("open", 10)
+    report.add_count_access_type("closed", 3)
+    report.add_count_experimental_strategy("WXS", 101)
+    report.add_count_access_location("San Francisco, CA, USA", 303)
+    report.add_count_project_id("TCGA-YYY", 3300)
     report.report_period = date.today()
 
     db_session.add(report)


### PR DESCRIPTION
Each `DataDownloadReport` JSONB column must now contain `downloaded_size_gb` and `user_interest_files_count` fields.

This is NOT a schema change but a model api change: renamed methods (`add_size_xxx`) and new ones (`add_count_xxx`).